### PR TITLE
ia16-elf-gcc: update documentation to mention (new) ia16-elf-gcc packages for Ubuntu Trusty

### DIFF
--- a/docs/build.txt
+++ b/docs/build.txt
@@ -37,8 +37,9 @@ You can now also cross compile with T.K. Chia's fork of ia16-elf-gcc,
 which is available at https://github.com/tkchia/gcc-ia16, using
 make all COMPILER=gcc
 or by setting COMPILER=gcc in config.mak. If you are using Ubuntu
-Linux 16.04 LTS (Xenial Xerus), there are precompiled ia16-elf-gcc
-packages at https://launchpad.net/~tkchia/+archive/ubuntu/build-ia16/.
+Linux 16.04 LTS (Xenial Xerus) or Ubuntu Linux 14.04 LTS (Trusty
+Tahr), there are precompiled ia16-elf-gcc packages at
+https://launchpad.net/~tkchia/+archive/ubuntu/build-ia16/.
 Otherwise, for now ia16-elf-gcc needs to be compiled from source.
 Only releases 20171210 and later are supported.
 


### PR DESCRIPTION
Hello @bartoldeman ,

I finally added packages for `ia16-elf-gcc` targeting Ubuntu 14.04 LTS (Trusty Tahr) --- in addition to 16.04 LTS --- to my Ubuntu PPA, and I thought it would be useful to mention that too in the `fdkernel` documentation.  The new Trusty packages can be used with the Travis CI service.

(_Update:_ I forced-updated my repository to straighten out the revision history.  My apologies for the earlier mess.)