### PR TITLE
Minor fixes for mkfiles/gcc.mak and utils/exeflat.c

### DIFF
--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -67,7 +67,7 @@ ifeq ($(LOADSEG)0, 0)
 LOADSEG=0x60
 endif
 
-INITPATCH=objcopy --redefine-sym ___umodsi3=_init_umodsi3 --redefine-sym ___udivsi3=_init_udivsi3 --redefine-sym ___ashlsi3=_init_ashlsi3 --redefine-sym ___lshrsi3=_init_lshrsi3
+INITPATCH=ia16-elf-objcopy --redefine-sym ___umodsi3=_init_umodsi3 --redefine-sym ___udivsi3=_init_udivsi3 --redefine-sym ___ashlsi3=_init_ashlsi3 --redefine-sym ___lshrsi3=_init_lshrsi3
 CLDEF=1
 CLT=gcc -DDOSC_TIME_H -I../hdr -o $@
 CLC=$(CLT)

--- a/utils/exeflat.c
+++ b/utils/exeflat.c
@@ -125,8 +125,8 @@ static int exeflat(const char *srcfile, const char *dstfile,
     ((DWORD) (header->exPages - 1) << 9) + header->exExtraBytes -
     header->exHeaderSize * 16UL;
   printf("image size (less header) = %lu = 0x%lx\n", size, size);
-  printf("first relocation offset = %u = 0x%u\n", header->exOverlay,
-         header->exOverlay);
+  printf("first relocation offset = %u = 0x%x\n", header->exRelocTable,
+         header->exRelocTable);
 
   /* first read file into memory chunks */
   fseek(src, header->exHeaderSize * 16UL, SEEK_SET);
@@ -150,7 +150,7 @@ static int exeflat(const char *srcfile, const char *dstfile,
     }
     if (fread(*curbuf, sizeof(char), bufsize, src) != bufsize)
     {
-      printf("Source file read error %ld %d\n", to_xfer, bufsize);
+      printf("Source file read error %ld %d\n", to_xfer, (int)bufsize);
       exit(1);
     }
   }
@@ -381,7 +381,7 @@ int main(int argc, char **argv)
         if (silentcount >= LENGTH(silentSegments))
         {
           printf("can't handle more then %d silent's\n",
-                 LENGTH(silentSegments));
+                 (int)LENGTH(silentSegments));
           exit(1);
         }
         


### PR DESCRIPTION
This patch fixes some minor problems in `mkfiles/gcc.mak` and `utils/exeflat.c`.

I found these while trying to modify the kernel code (still in progress) to use the `MZ` relocation support which I had newly added to my GCC toolchain.