### PR TITLE
Simplify ia16-elf-gcc port, by taking advantage of recently-added gcc features

### DIFF
--- a/docs/build.txt
+++ b/docs/build.txt
@@ -41,7 +41,7 @@ Linux 16.04 LTS (Xenial Xerus) or Ubuntu Linux 14.04 LTS (Trusty
 Tahr), there are precompiled ia16-elf-gcc packages at
 https://launchpad.net/~tkchia/+archive/ubuntu/build-ia16/.
 Otherwise, for now ia16-elf-gcc needs to be compiled from source.
-Only releases 20180419 and later are supported.
+Only releases 20180708 and later are supported.
 
 Notes:
 ======

--- a/docs/build.txt
+++ b/docs/build.txt
@@ -41,7 +41,7 @@ Linux 16.04 LTS (Xenial Xerus) or Ubuntu Linux 14.04 LTS (Trusty
 Tahr), there are precompiled ia16-elf-gcc packages at
 https://launchpad.net/~tkchia/+archive/ubuntu/build-ia16/.
 Otherwise, for now ia16-elf-gcc needs to be compiled from source.
-Only releases 20171210 and later are supported.
+Only releases 20180419 and later are supported.
 
 Notes:
 ======

--- a/hdr/portab.h
+++ b/hdr/portab.h
@@ -337,7 +337,11 @@ typedef signed long LONG;
 #define FP_SEG(fp)            ((unsigned)((ULONG)(VOID FAR *)(fp)>>16))
 #endif
 
+#if defined(__GNUC__) && defined(__BUILTIN_IA16_FP_OFF)
+#define FP_OFF(fp)            __builtin_ia16_FP_OFF(fp)
+#else
 #define FP_OFF(fp)            ((unsigned)(fp))
+#endif
 
 #endif
 #endif

--- a/kernel/init-dat.h
+++ b/kernel/init-dat.h
@@ -28,9 +28,8 @@ extern __segment DosTextSeg;
 #elif defined(__GNUC__)
 
 #define DosTextSeg 0x70
-/* XXX not supported yet */
-#define DOSFAR
-#define DOSTEXTFAR
+#define DOSFAR FAR
+#define DOSTEXTFAR FAR
 #undef DOSDATA
 #undef DOSTEXT
 #define DOSDATA(x) (*(typeof(x) FAR *)MK_FP(DosDataSeg, (size_t)&(x)))

--- a/kernel/init-mod.h
+++ b/kernel/init-mod.h
@@ -265,38 +265,21 @@ extern char master_env[128];
 extern struct lol FAR *LoL;
 
 extern struct dhdr DOSTEXTFAR ASM blk_dev; /* Block device (Disk) driver           */
-#define blk_dev DOSTEXT(blk_dev)
 
 extern struct buffer FAR *DOSFAR firstAvailableBuf; /* first 'available' buffer   */
-#define firstAvailableBuf DOSDATA(firstAvailableBuf)
-#ifdef __GNUC__
-extern struct lol ASM DATASTART;
-#else
 extern struct lol ASM FAR DATASTART;
-#endif
-#define DATASTART DOSDATA(DATASTART)
 
 extern BYTE DOSFAR ASM _HMATextAvailable;    /* first byte of available CODE area    */
-#ifdef __GNUC__
-extern BYTE ASM _HMATextStart[];          /* first byte of HMAable CODE area      */
-extern BYTE ASM _HMATextEnd[];
-#else
 extern BYTE FAR ASM _HMATextStart[];          /* first byte of HMAable CODE area      */
 extern BYTE FAR ASM _HMATextEnd[];
-#endif
 extern BYTE DOSFAR ASM break_ena;  /* break enabled flag                   */
-#define break_ena DOSDATA(break_ena)
-extern BYTE DOSFAR ASM _InitTextStart[],     /* first available byte of ram          */
-  DOSFAR ASM _InitTextEnd[],
-  DOSFAR ASM ReturnAnyDosVersionExpected,
-  DOSFAR ASM HaltCpuWhileIdle;
-#define ReturnAnyDosVersionExpected DOSDATA(ReturnAnyDosVersionExpected)
-#define HaltCpuWhileIdle DOSDATA(HaltCpuWhileIdle)
+extern BYTE DOSFAR ASM _InitTextStart[];     /* first available byte of ram          */
+extern BYTE DOSFAR ASM _InitTextEnd[];
+extern BYTE DOSFAR ASM ReturnAnyDosVersionExpected;
+extern BYTE DOSFAR ASM HaltCpuWhileIdle;
 
 extern BYTE DOSFAR ASM internal_data[];
-#define internal_data DOSDATA(internal_data)
 extern unsigned char DOSTEXTFAR ASM kbdType;
-#define kbdType DOSTEXT(kbdType)
 
 extern struct {
   char  ThisIsAConstantOne;
@@ -305,29 +288,23 @@ extern struct {
   struct CountrySpecificInfo C;
   
 } DOSFAR ASM nlsCountryInfoHardcoded;
-#define nlsCountryInfoHardcoded DOSDATA(nlsCountryInfoHardcoded)
-#define nlsPackageHardcoded DOSDATA(nlsPackageHardcoded)
 
 /*
     data shared between DSK.C and INITDISK.C
 */
 
 extern UWORD DOSFAR LBA_WRITE_VERIFY;
-#define LBA_WRITE_VERIFY DOSDATA(LBA_WRITE_VERIFY)
 
 /* original interrupt vectors, at 70:xxxx */
 extern struct lowvec {
   unsigned char intno;
   intvec isv;
 } DOSTEXTFAR ASM intvec_table[5];
-#define intvec_table DOSTEXT(intvec_table)
 
 /* floppy parameter table, at 70:xxxx */
 extern unsigned char DOSTEXTFAR ASM int1e_table[0xe];
-#define int1e_table DOSTEXT(int1e_table)
 
 extern char DOSFAR DiskTransferBuffer[/*MAX_SEC_SIZE*/]; /* in dsk.c */
-#define DiskTransferBuffer DOSDATA(DiskTransferBuffer)
 
 struct RelocationTable {
   UBYTE jmpFar;
@@ -345,14 +322,10 @@ struct RelocatedEntry {
   UWORD jmpSegment;
 };
 
-extern struct RelocationTable
-   DOSFAR ASM _HMARelocationTableStart[],
-   DOSFAR ASM _HMARelocationTableEnd[];
-#define _HMARelocationTableStart DOSDATA(_HMARelocationTableStart)
-#define _HMARelocationTableEnd DOSDATA(_HMARelocationTableEnd)
+extern struct RelocationTable DOSFAR ASM _HMARelocationTableStart[];
+extern struct RelocationTable DOSFAR ASM _HMARelocationTableEnd[];
 
 extern void FAR *DOSFAR ASM XMSDriverAddress;
-#define XMSDriverAddress DOSDATA(XMSDriverAddress)
 #ifdef __GNUC__
 extern VOID _EnableA20(VOID);
 extern VOID _DisableA20(VOID);

--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -938,18 +938,6 @@ global %1lshrsi3
                 ; reserve space for far jump to cp/m routine
                 times 5 db 0
 
-%ifdef gcc
-blk_driver_wrap:mov ax, _blk_driver
-                jmp short blkclk
-clk_driver_wrap:mov ax, _clk_driver
-blkclk:         pop si
-                pop di
-                call ax
-                push di
-                push si
-                retf
-%endif
-
 ;End of HMA segment                
 segment HMA_TEXT_END
                 global  __HMATextEnd
@@ -1042,21 +1030,13 @@ _cpm_entry:     jmp 0:reloc_call_cpm_entry
                 global  _reloc_call_blk_driver
                 extern  _blk_driver
 _reloc_call_blk_driver:
-%ifdef gcc
-                jmp 0:blk_driver_wrap
-%else
                 jmp 0:_blk_driver
-%endif
                 call near forceEnableA20
 
                 global  _reloc_call_clk_driver
                 extern  _clk_driver
 _reloc_call_clk_driver:
-%ifdef gcc
-                jmp 0:clk_driver_wrap
-%else
                 jmp 0:_clk_driver
-%endif
                 call near forceEnableA20
 
                 global  _CharMapSrvc ; in _DATA (see AARD)

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -4,7 +4,7 @@
 OUTPUT_FORMAT(binary)
 
 DOS_PSP = 0x60;
-MEMOFS = DOS_PSP * 16 - SIZEOF(.hdr);
+MEMOFS = DOS_PSP * 16 - SIZEOF(.msdos_mz_hdr);
 
 /* these GROUPs play the same role as GROUPS (segments) in OMF */
 PGROUP = (MEMOFS + LOADADDR(.ptext)) / 16;
@@ -22,7 +22,7 @@ SECTIONS
     /* Fabricate a .exe header here.  Although libbfd does have an
        "i386msdos" back-end which produces an "MZ" exe header, it cannot do
        certain things (yet). */
-    .hdr : {
+    .msdos_mz_hdr : {
 		/* Signature.  */
 		SHORT (0x5a4d)
 		/* Bytes in last 512-byte page.  */
@@ -30,9 +30,9 @@ SECTIONS
 		/* Total number of 512-byte pages.  */
 		SHORT (ALIGN(LOADADDR (.ibss), 512) / 512)
 		/* Relocation entries.  */
-		SHORT (0)
+		SHORT ((__msdos_mz_rel_end - __msdos_mz_rel_start) / 4)
 		/* Header size in paragraphs.  */
-		SHORT (SIZEOF(.hdr) / 16)
+		SHORT (SIZEOF(.msdos_mz_hdr) / 16)
 		/* Minimum extra paragraphs.  */
 		SHORT (ALIGN(SIZEOF (.ibss) + SIZEOF(.istack), 16) / 16)
 		/* Maximum extra paragraphs.  */
@@ -45,12 +45,18 @@ SECTIONS
 		. = 0x18;
 		/* Relocation table offset.  */
 		SHORT (. + 4)
-		/* Overlay number + padding */
-                . = ALIGN (32);
+		/* Overlay number  */
+		SHORT (0)
+		/* Relocations  */
+		HIDDEN (__msdos_mz_rel_start = .);
+		*(.msdos_mz_reloc .msdos_mz_reloc.*)
+		HIDDEN (__msdos_mz_rel_end = .);
+		/* Padding */
+                . = ALIGN (16);
     }
 
     /* Target PSP section.  */
-    .ptext 0 : AT (SIZEOF(.hdr)) {
+    .ptext 0 : AT (SIZEOF(.msdos_mz_hdr)) {
 		*(PSP)
     }
 

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -68,12 +68,7 @@ __segment DosTextSeg = 0;
 
 #endif
 
-struct lol FAR *LoL
-#ifndef __GNUC__
-/* cannot initialize from far data with GCC */
-= &DATASTART;
-#endif
-;
+struct lol FAR *LoL = &DATASTART;
 
 VOID ASMCFUNC FreeDOSmain(void)
 {
@@ -95,9 +90,6 @@ VOID ASMCFUNC FreeDOSmain(void)
                             at 50:e0
                         */
 
-#ifdef __GNUC__
-  LoL = &DATASTART;
-#endif
   drv = LoL->BootDrive + 1;
   p = MK_FP(0, 0x5e0);
   if (fmemcmp(p+2,"CONFIG",6) == 0)      /* UPX */

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -54,8 +54,9 @@ CFLAGSC=
 # -Wno-pointer-to-int-cast  do not warn about FP_OFF
 # -Wno-pragmas  do not warn about #pragma pack
 # -Werror       treat all warnings as errors
+# -mfar-function-if-far-return-type treat `int __far f ();' as a far function
 
-ALLCFLAGS+=-I../hdr $(TARGETOPT) -mcmodel=small -fleading-underscore -fno-common -fpack-struct -ffreestanding -fcall-used-es -mrtd -Wno-pointer-to-int-cast -Wno-pragmas -Werror -Os -fno-strict-aliasing
+ALLCFLAGS+=-I../hdr $(TARGETOPT) -mcmodel=small -fleading-underscore -fno-common -fpack-struct -ffreestanding -fcall-used-es -mrtd -Wno-pointer-to-int-cast -Wno-pragmas -Werror -Os -fno-strict-aliasing -mfar-function-if-far-return-type
 INITCFLAGS=$(ALLCFLAGS) -o $@
 CFLAGS=$(ALLCFLAGS) -o $@
 


### PR DESCRIPTION
The proposed patches take advantage of `gcc-ia16`'s new support for far static variables, and for the classical `int __far f (`...`);` syntax for far function declarations.

As a side effect, I also had to change a few other things:
  * The linker script had to be modified to handle `MZ`-style relocations (which will later be processed by `exeflat`).
  * I changed the definition of `FP_OFF (.)` (to make use of a new built-in function I just added to GCC).  This is so that we can write e.g. `FP_OFF (int0_handler)` inside a static initializer, when `int0_handler` is now a far function.

I hope the patches are fine with you.  Thank you!